### PR TITLE
Fix "unexpected keyword argument" error with recent IPykernel versions

### DIFF
--- a/ferretmagic/ferretmagic.py
+++ b/ferretmagic/ferretmagic.py
@@ -479,7 +479,7 @@ def run_cell_new(self, raw_cell, store_history=False, silent=False, shell_future
       # We're going to add a %%ferret to the top
       raw_cell = "%%ferret\n" + raw_cell
 
-  return self.run_cell_a(raw_cell, store_history, silent, shell_futures)
+  return self.run_cell_a(raw_cell, store_history, silent, shell_futures, **kwargs)
 
 # And assign it
 InteractiveShell.run_cell = run_cell_new

--- a/ferretmagic/ferretmagic.py
+++ b/ferretmagic/ferretmagic.py
@@ -467,7 +467,7 @@ if not getattr(InteractiveShell, "run_cell_a", False):
   InteractiveShell.run_cell_a = InteractiveShell.run_cell
 
 # Now rewrite run_cell
-def run_cell_new(self, raw_cell, store_history=False, silent=False, shell_futures=True):
+def run_cell_new(self, raw_cell, store_history=False, silent=False, shell_futures=True, **kwargs):
   
   # Are we locked in pyferret?
   if getattr(self, "ferret_locked", False):


### PR DESCRIPTION
This is a quick fix for the problem

```
[IPKernelApp] ERROR | Exception in message handler:
Traceback (most recent call last):
  File "/miniconda3/envs/climPOOGCM/lib/python3.9/site-packages/ipykernel/kernelbase.py", line 406, in dispatch_shell
    await result
  File "/miniconda3/envs/climPOOGCM/lib/python3.9/site-packages/ipykernel/kernelbase.py", line 730, in execute_request
    reply_content = await reply_content
  File "/miniconda3/envs/climPOOGCM/lib/python3.9/site-packages/ipykernel/ipkernel.py", line 383, in do_execute
    res = shell.run_cell(
  File "/miniconda3/envs/climPOOGCM/lib/python3.9/site-packages/ipykernel/zmqshell.py", line 528, in run_cell
    return super().run_cell(*args, **kwargs)
TypeError: run_cell_new() got an unexpected keyword argument 'cell_id'
```

which seems to be caused by (recent? I am using v6.15.0, see below) changes in the IPykernel code. I assume `cell_id` is not important for `ipython_ferretmagic` functionality, so catching the error by adding a `**kwargs` to `run_cell_new()` should be sufficient? I have tested it against [this example Jupyter notebook](https://github.com/PBrockmann/ipython_ferretmagic/blob/81a19c79924ed5a23e3ed59bcc729de563002569/notebooks/ferretBasics.ipynb), which seems to run through. (Only having a problem with finding the `mpl_Div_BrBG` colormap in cell 21, but that's a different "construction site", as other colormaps seem to be working.)

Package versions...
```
$ pip freeze > pip.txt
$ cat pip.txt
asttokens @ file:///home/conda/feedstock_root/build_artifacts/asttokens_1618968359944/work
backcall @ file:///home/conda/feedstock_root/build_artifacts/backcall_1592338393461/work
backports.functools-lru-cache @ file:///home/conda/feedstock_root/build_artifacts/backports.functools_lru_cache_1618230623929/work
certifi==2022.6.15
cftime @ file:///home/conda/feedstock_root/build_artifacts/cftime_1649636863755/work
cycler @ file:///home/conda/feedstock_root/build_artifacts/cycler_1635519461629/work
debugpy @ file:///home/conda/feedstock_root/build_artifacts/debugpy_1649586347330/work
decorator @ file:///home/conda/feedstock_root/build_artifacts/decorator_1641555617451/work
entrypoints @ file:///home/conda/feedstock_root/build_artifacts/entrypoints_1643888246732/work
executing @ file:///home/conda/feedstock_root/build_artifacts/executing_1646044401614/work
ferretmagic @ git+https://github.com/kathoef/ipython_ferretmagic.git@d635e09ee8033b9392bc705d245c967349544a2a
fonttools @ file:///home/conda/feedstock_root/build_artifacts/fonttools_1651017733844/work
gcircle==7.63
ipykernel @ file:///home/conda/feedstock_root/build_artifacts/ipykernel_1655369107642/work
ipython @ file:///home/conda/feedstock_root/build_artifacts/ipython_1653754934243/work
jedi @ file:///home/conda/feedstock_root/build_artifacts/jedi_1649067096717/work
jupyter-client @ file:///home/conda/feedstock_root/build_artifacts/jupyter_client_1654730843242/work
jupyter-core @ file:///home/conda/feedstock_root/build_artifacts/jupyter_core_1652365269273/work
kiwisolver @ file:///home/conda/feedstock_root/build_artifacts/kiwisolver_1655141579806/work
matplotlib @ file:///home/conda/feedstock_root/build_artifacts/matplotlib-suite_1651609462317/work
matplotlib-inline @ file:///home/conda/feedstock_root/build_artifacts/matplotlib-inline_1631080358261/work
munkres==1.1.4
nest-asyncio @ file:///home/conda/feedstock_root/build_artifacts/nest-asyncio_1648959695634/work
netCDF4 @ file:///home/conda/feedstock_root/build_artifacts/netcdf4_1636302994507/work
numpy @ file:///home/conda/feedstock_root/build_artifacts/numpy_1653325313343/work
packaging @ file:///home/conda/feedstock_root/build_artifacts/packaging_1637239678211/work
parso @ file:///home/conda/feedstock_root/build_artifacts/parso_1638334955874/work
pexpect @ file:///home/conda/feedstock_root/build_artifacts/pexpect_1602535608087/work
pickleshare @ file:///home/conda/feedstock_root/build_artifacts/pickleshare_1602536217715/work
Pillow @ file:///home/conda/feedstock_root/build_artifacts/pillow_1653922716870/work
pipedviewer==7.63
prompt-toolkit @ file:///home/conda/feedstock_root/build_artifacts/prompt-toolkit_1649130487073/work
psutil @ file:///home/conda/feedstock_root/build_artifacts/psutil_1653089170447/work
ptyprocess @ file:///home/conda/feedstock_root/build_artifacts/ptyprocess_1609419310487/work/dist/ptyprocess-0.7.0-py2.py3-none-any.whl
pure-eval @ file:///home/conda/feedstock_root/build_artifacts/pure_eval_1642875951954/work
pyferret==7.63
Pygments @ file:///home/conda/feedstock_root/build_artifacts/pygments_1650904496387/work
pyparsing @ file:///home/conda/feedstock_root/build_artifacts/pyparsing_1652235407899/work
PyQt5==5.12.3
PyQt5_sip==4.19.18
PyQtChart==5.12
PyQtWebEngine==5.12.1
pyshp @ file:///home/conda/feedstock_root/build_artifacts/pyshp_1651509119669/work
python-dateutil @ file:///home/conda/feedstock_root/build_artifacts/python-dateutil_1626286286081/work
pyzmq @ file:///home/conda/feedstock_root/build_artifacts/pyzmq_1654181414960/work
scipy @ file:///home/conda/feedstock_root/build_artifacts/scipy_1653073865807/work
six @ file:///home/conda/feedstock_root/build_artifacts/six_1620240208055/work
stack-data @ file:///home/conda/feedstock_root/build_artifacts/stack_data_1655315839047/work
tornado @ file:///home/conda/feedstock_root/build_artifacts/tornado_1648827245914/work
traitlets @ file:///home/conda/feedstock_root/build_artifacts/traitlets_1655411388954/work
unicodedata2 @ file:///home/conda/feedstock_root/build_artifacts/unicodedata2_1649111919389/work
wcwidth @ file:///home/conda/feedstock_root/build_artifacts/wcwidth_1600965781394/work
```

```
$ conda list --export > conda.txt
$ cat conda.txt
# This file may be used to create an environment using:
# $ conda create --name <env> --file <this file>
# platform: linux-64
_libgcc_mutex=0.1=conda_forge
_openmp_mutex=4.5=2_gnu
alsa-lib=1.2.6.1=h7f98852_0
asttokens=2.0.5=pyhd8ed1ab_0
backcall=0.2.0=pyh9f0ad1d_0
backports=1.0=py_2
backports.functools_lru_cache=1.6.4=pyhd8ed1ab_0
brotli=1.0.9=h166bdaf_7
brotli-bin=1.0.9=h166bdaf_7
bzip2=1.0.8=h7f98852_4
c-ares=1.18.1=h7f98852_0
ca-certificates=2022.6.15=ha878542_0
cairo=1.16.0=ha12eb4b_1010
certifi=2022.6.15=py39hf3d152e_0
cftime=1.6.0=py39hd257fcd_1
curl=7.83.1=h2283fc2_0
cycler=0.11.0=pyhd8ed1ab_0
dbus=1.13.6=h5008d03_3
debugpy=1.6.0=py39h5a03fae_0
decorator=5.1.1=pyhd8ed1ab_0
entrypoints=0.4=pyhd8ed1ab_0
executing=0.8.3=pyhd8ed1ab_0
expat=2.4.8=h27087fc_0
ferret_datasets=7.6=0
ferretmagic=20200603=pypi_0
font-ttf-dejavu-sans-mono=2.37=hab24e00_0
font-ttf-inconsolata=3.000=h77eed37_0
font-ttf-source-code-pro=2.038=h77eed37_0
font-ttf-ubuntu=0.83=hab24e00_0
fontconfig=2.14.0=h8e229c2_0
fonts-conda-ecosystem=1=0
fonts-conda-forge=1=0
fonttools=4.33.3=py39hb9d737c_0
freetype=2.10.4=h0708190_1
fribidi=1.0.10=h36c2ea0_0
gettext=0.19.8.1=h73d1719_1008
giflib=5.2.1=h36c2ea0_2
glib=2.70.2=h780b84a_4
glib-tools=2.70.2=h780b84a_4
graphite2=1.3.13=h58526e2_1001
gst-plugins-base=1.20.3=hf6a322e_0
gstreamer=1.20.3=hd4edc92_0
harfbuzz=3.4.0=hb4a5f5f_0
hdf4=4.2.15=h10796ff_3
hdf5=1.12.1=nompi_h4df4325_104
icu=69.1=h9c3ff4c_0
ipykernel=6.15.0=pyh210e3f2_0
ipython=8.4.0=py39hf3d152e_0
jedi=0.18.1=py39hf3d152e_1
jpeg=9e=h166bdaf_1
jupyter_client=7.3.4=pyhd8ed1ab_0
jupyter_core=4.10.0=py39hf3d152e_0
keyutils=1.6.1=h166bdaf_0
kiwisolver=1.4.3=py39hf939315_0
krb5=1.19.3=h08a2579_0
lcms2=2.12=hddcbb42_0
ld_impl_linux-64=2.36.1=hea4e1c9_2
lerc=3.0=h9c3ff4c_0
libblas=3.9.0=15_linux64_openblas
libbrotlicommon=1.0.9=h166bdaf_7
libbrotlidec=1.0.9=h166bdaf_7
libbrotlienc=1.0.9=h166bdaf_7
libcblas=3.9.0=15_linux64_openblas
libclang=13.0.1=default_hc23dcda_0
libcurl=7.83.1=h2283fc2_0
libdeflate=1.12=h166bdaf_0
libedit=3.1.20191231=he28a2e2_2
libev=4.33=h516909a_1
libevent=2.1.10=h28343ad_4
libffi=3.4.2=h7f98852_5
libgcc-ng=12.1.0=h8d9b700_16
libgfortran-ng=12.1.0=h69a702a_16
libgfortran5=12.1.0=hdcd56e2_16
libglib=2.70.2=h174f98d_4
libgomp=12.1.0=h8d9b700_16
libiconv=1.16=h516909a_0
liblapack=3.9.0=15_linux64_openblas
libllvm13=13.0.1=hf817b99_2
libnetcdf=4.8.1=nompi_h329d8a1_102
libnghttp2=1.47.0=he49606f_0
libnsl=2.0.0=h7f98852_0
libogg=1.3.4=h7f98852_1
libopenblas=0.3.20=pthreads_h78a6416_0
libopus=1.3.1=h7f98852_1
libpng=1.6.37=h21135ba_2
libpq=14.4=he2d8382_0
libsodium=1.0.18=h36c2ea0_1
libssh2=1.10.0=ha35d2d1_2
libstdcxx-ng=12.1.0=ha89aaad_16
libtiff=4.4.0=hc85c160_1
libuuid=2.32.1=h7f98852_1000
libvorbis=1.3.7=h9c3ff4c_0
libwebp=1.2.2=h3452ae3_0
libwebp-base=1.2.2=h7f98852_1
libxcb=1.13=h7f98852_1004
libxkbcommon=1.0.3=he3ba5ed_0
libxml2=2.9.12=h885dcf4_1
libzip=1.8.0=h1c5bbd1_1
libzlib=1.2.12=h166bdaf_1
lz4-c=1.9.3=h9c3ff4c_1
matplotlib=3.5.2=py39hf3d152e_0
matplotlib-base=3.5.2=py39h700656a_0
matplotlib-inline=0.1.3=pyhd8ed1ab_0
munkres=1.1.4=pyh9f0ad1d_0
mysql-common=8.0.29=h26416b9_1
mysql-libs=8.0.29=hbc51c84_1
ncurses=6.3=h27087fc_1
nest-asyncio=1.5.5=pyhd8ed1ab_0
netcdf-fortran=4.5.4=nompi_h2b6e579_100
netcdf4=1.5.8=nompi_py39h64b754b_101
nspr=4.32=h9c3ff4c_1
nss=3.78=h2350873_0
numpy=1.22.4=py39hc58783e_0
openjpeg=2.4.0=hb52868f_1
openssl=3.0.4=h166bdaf_0
packaging=21.3=pyhd8ed1ab_0
pango=1.48.10=h4dcc4a0_3
parso=0.8.3=pyhd8ed1ab_0
pcre=8.45=h9c3ff4c_0
pexpect=4.8.0=pyh9f0ad1d_2
pickleshare=0.7.5=py_1003
pillow=9.1.1=py39hae2aec6_1
pip=22.1.2=pyhd8ed1ab_0
pipedviewer=7.63=pypi_0
pixman=0.40.0=h36c2ea0_0
prompt-toolkit=3.0.29=pyha770c72_0
psutil=5.9.1=py39hb9d737c_0
pthread-stubs=0.4=h36c2ea0_1001
ptyprocess=0.7.0=pyhd3deb0d_0
pure_eval=0.2.2=pyhd8ed1ab_0
pyferret=7.63=pypi_0
pygments=2.12.0=pyhd8ed1ab_0
pyparsing=3.0.9=pyhd8ed1ab_0
pyqt=5.12.3=py39h03dd644_4
pyqt5-sip=4.19.18=pypi_0
pyqtchart=5.12=pypi_0
pyqtwebengine=5.12.1=pypi_0
pyshp=2.3.0=pyhd8ed1ab_0
python=3.9.13=h2660328_0_cpython
python-dateutil=2.8.2=pyhd8ed1ab_0
python_abi=3.9=2_cp39
pyzmq=23.1.0=py39headdf64_0
qt=5.12.9=h1304e3e_6
readline=8.1.2=h0f457ee_0
scipy=1.8.1=py39he49c0e8_0
setuptools=62.6.0=py39hf3d152e_0
six=1.16.0=pyh6c4a22f_0
sqlite=3.38.5=h4ff8645_0
stack_data=0.3.0=pyhd8ed1ab_0
tk=8.6.12=h27826a3_0
tornado=6.1=py39hb9d737c_3
traitlets=5.3.0=pyhd8ed1ab_0
tzdata=2022a=h191b570_0
unicodedata2=14.0.0=py39hb9d737c_1
wcwidth=0.2.5=pyh9f0ad1d_2
wheel=0.37.1=pyhd8ed1ab_0
xorg-kbproto=1.0.7=h7f98852_1002
xorg-libice=1.0.10=h7f98852_0
xorg-libsm=1.2.3=hd9c2040_1000
xorg-libx11=1.7.2=h7f98852_0
xorg-libxau=1.0.9=h7f98852_0
xorg-libxdmcp=1.1.3=h7f98852_0
xorg-libxext=1.3.4=h7f98852_1
xorg-libxrender=0.9.10=h7f98852_1003
xorg-renderproto=0.11.1=h7f98852_1002
xorg-xextproto=7.3.0=h7f98852_1002
xorg-xproto=7.0.31=h7f98852_1007
xz=5.2.5=h516909a_1
zeromq=4.3.4=h9c3ff4c_1
zlib=1.2.12=h166bdaf_1
zstd=1.5.2=h8a70e8d_1
```